### PR TITLE
Take2 on secret scanning error

### DIFF
--- a/src/Config/config.js
+++ b/src/Config/config.js
@@ -1,3 +1,6 @@
 // AWS Access Key and Secret Key for testing Secret Scanning.
 const AWS_ACCESS_KEY_ID = "AKIA123456789078905L";
 const AWS_SECRET_ACCESS_KEY = "IHF+fhtWyjceTso+J4/o4zQttW7dxYrjCnLG9KqC";
+
+// Adafruit IO Key for testing Secret Scanning (no validity check).
+const ADAFRUIT_IO_KEY = "a1b2c3d4e5f678901234567890abcdef";


### PR DESCRIPTION
Take2 on secret scanning error
Turns out it can check AWS secrets for validity